### PR TITLE
Issue: #11. Consider time zone offset when calculating start time for the LRE

### DIFF
--- a/src/main/java/nl/stokpop/lograter/processor/performancecenter/PerformanceCenterCalculator.java
+++ b/src/main/java/nl/stokpop/lograter/processor/performancecenter/PerformanceCenterCalculator.java
@@ -79,7 +79,7 @@ public final class PerformanceCenterCalculator {
         // the offset is bigger because it seems HP is adding DST to epoch time???
         final long dayLightSavingsOffset = isDayLightSavingActive ? -3600 : 0;
 
-        final long localStartTimeSecEpoch = testStartTimeSecEpoch + dayLightSavingsOffset;
+        final long localStartTimeSecEpoch = testStartTimeSecEpoch + timeZoneOffset + dayLightSavingsOffset;
 
         log.info("In [{}] {}: " +
                         "StartTimeSecEpoch [{}] timeZoneOffset [{}] makes start time of test data [{}] ([{}] seconds since epoch)",

--- a/src/test/java/nl/stokpop/lograter/processor/performancecenter/AbstractPerformanceCenterResultsReaderTest.java
+++ b/src/test/java/nl/stokpop/lograter/processor/performancecenter/AbstractPerformanceCenterResultsReaderTest.java
@@ -23,56 +23,31 @@ public class AbstractPerformanceCenterResultsReaderTest {
 
     @Test
     public void calculateLocalStartTimeInSecondsEpochWinterTime() {
-        // HP logic for time in the results db seems to use GMT instead of actual timezone
-        // to get to local time.
+        // LRE logic for time in the results db uses zone-based time instead of UTC.
+        // Same table also contains time zone offset.
 
-        // The actual start time is 14:34:47 local time (winter time)
+        // The actual start time is 14:34:47 "Europe/Amsterdam" zone time (winter time)
         // date --date=@1512653687
         // Thu Dec  7 14:34:47 CET 2017
 
         final long startTimeInSecondsEpoch = 1512653687;
         final long timeZoneOffset = -3600;
+        final long expectedResult = startTimeInSecondsEpoch + timeZoneOffset;
         long startTime = PerformanceCenterCalculator.calculateLocalStartTimeSecEpoch(startTimeInSecondsEpoch, timeZoneOffset);
-        assertEquals(startTimeInSecondsEpoch, startTime);
-
-    }
-
-    @Test
-    public void calculateLocalStartTimeInSecondsEpochWinterTime2() {
-        //	Analysis Summary Period: 10/11/2017 15:27:48 - 10/11/2017 15:31:39
-        //Result ID	Scenario Name	Result Name	Time Zone	Start Time	Result End Time
-        //0	Scenario1	res1696.lrr	-3600	1510324068	1510324299
-        //	ScenarioTimeZone=-3600
-        //	DaylightSavingSecsAddition=0
-        //	ScenarioStartTime=1510324068
-        //	ScenarioEndTime=1510324300
-
-        final long startTimeInSecondsEpoch = 1510324068;
-        final long timeZoneOffset = -3600;
-        long startTime = PerformanceCenterCalculator.calculateLocalStartTimeSecEpoch(startTimeInSecondsEpoch, timeZoneOffset);
-        assertEquals(startTimeInSecondsEpoch, startTime);
+        assertEquals(expectedResult, startTime);
     }
 
     @Test
     public void calculateLocalStartTimeInSecondsEpochSummerTime() {
-        //Analysis Summary Period: 25-10-2017 00:27:22 - 25-10-2017 00:39:57
-        // result.mdb / result
-        //Result ID	Scenario Name	Result Name	Time Zone	Start Time	Result End Time
-        //0	Scenario1	res290.lrr	-3600	1508887642	1508888397
-        //	ScenarioTimeZone=-3600
-        //	DaylightSavingSecsAddition=3600
-        //	ScenarioStartTime=1508887642
-        //	ScenarioEndTime=1508888398
-
-        // date --date @1508887642
-        // Wed Oct 25 01:27:22 CEST 2017
-
-        // date --date @1508884042
-        // Wed Oct 25 00:27:22 CEST 2017
+        // The actual start time is 1:27:22 "Europe/Amsterdam" zone time (summer time)
+        // date --date=@1508887642
+        // Wed Oct  25 1:27:22 DST 2017
 
         final long startTimeInSecondsEpoch = 1508887642;
         final long timeZoneOffset = -3600;
+        final long dayLightTimeOffset = -3600;
+        final long expectedResult = startTimeInSecondsEpoch + timeZoneOffset + dayLightTimeOffset;
         long startTime = PerformanceCenterCalculator.calculateLocalStartTimeSecEpoch(startTimeInSecondsEpoch, timeZoneOffset);
-        assertEquals(startTimeInSecondsEpoch - 3600, startTime);
+        assertEquals(expectedResult, startTime);
     }
 }


### PR DESCRIPTION
According to OpenText, LRE stores zone-based time in 'Results' table 'Start Time' column. Time offset is stored in 'Results' table 'Time Zone' column. Hence, correct calculation result is expected to consider time zone offset value for LRE flow.